### PR TITLE
Option to set a message size limit

### DIFF
--- a/src/file_set.rs
+++ b/src/file_set.rs
@@ -181,4 +181,9 @@ impl FileSet {
         self.closed_indexes.insert(ind.starting_offset(), ind);
         Ok(())
     }
+
+    //getter method to retrieve the max bytes set per message 
+    pub fn get_message_max_bytes(&self) -> usize {
+        self.opts.message_max_bytes
+    }
 }


### PR DESCRIPTION
For now I made a default message size limit at 1mb. Should there be an option where no message size limit is added or should there always be a limit? 