### PR TITLE
Clarify docs about the message size limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,7 @@ impl LogOptions {
     /// Creates minimal log options value with a directory containing the log.
     ///
     /// The default values are:
+    ///
     /// - *segment_max_bytes*: 1GB
     /// - *index_max_entries*: 100,000
     /// - *message_max_bytes*: 1mb


### PR DESCRIPTION
Hi, just trying this crate and made some minor updates to the docs about the message size limit

- minor wording
- added a doctest just as an example of the message size limit
- added a actual test just to pin that header size in the tests 