### PR TITLE
Make message_max_bytes encoding independent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,7 @@ impl LogOptions {
     /// Creates minimal log options value with a directory containing the log.
     ///
     /// The default values are:
+    ///
     /// - *segment_max_bytes*: 1GB
     /// - *index_max_entries*: 100,000
     /// - *message_max_bytes*: 1mb
@@ -965,5 +966,14 @@ mod tests {
         // push in an empty message
         buf.push(b"");
         assert_eq!(buf.bytes().len(), 20);
+    }
+
+    #[test]
+    pub fn message_limit_0_works() {
+        let mut opts = LogOptions::new("log");
+        opts.message_max_bytes(0);
+        let mut log = CommitLog::new(opts).unwrap();
+        assert!(log.append_msg([].as_ref()).is_ok());
+        assert!(log.append_msg([1u8].as_ref()).is_err());
     }
 }


### PR DESCRIPTION
Add internal const (MSG_HEADER_LEN) to track the message header length,
and a unit test to make sure the size does not change unexpectedly.

1. Check message_max_bytes when opening a log, to make sure it is not
   too large for the message header. Return an error if it is not.
2. Check serialized messages against message_max_bytes+MSG_HEADER_LEN.

An alternative to https://github.com/zowens/commitlog/pull/6#issuecomment-318115165 the API remains unchanged, but to avoid changing the API I wrap the size error in io::Error and delay failure to CommitLog::new()