### PR TITLE
Fix #11 - Can't recover index with single message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,6 +738,22 @@ mod tests {
     }
 
     #[test]
+    pub fn reopen_log_with_one_segment_write() {
+        env_logger::try_init().unwrap_or(());
+        let dir = TestDir::new();
+        let mut opts = LogOptions::new(&dir);
+        {
+            let mut log = CommitLog::new(opts.clone()).unwrap();
+            log.append_msg("Test");
+            log.flush().unwrap();
+        }
+        {
+            let mut log = CommitLog::new(opts.clone()).unwrap();
+            assert_eq!(1, log.next_offset());
+        }
+    }
+
+    #[test]
     pub fn append_message_greater_than_max() {
         let dir = TestDir::new();
         let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();


### PR DESCRIPTION
If we were ever opening an existing index with
exactly one message, that one message would get
lost and not show up when reading back the logs.

When starting up and opening an existing index,
we binary search to find the first "empty slot".

We did so by checking if rel_off was 0, assuming
this would never be the case.  If we ever had more
than one message in the index, this would work
because we'd hit the second message before we
checked the first message.  However, if we had
exactly one message in a segment, it would have a
rel_off of 0, and so the index would thing the whole
index was empty and overwrite this message.

Instead, we use the file_off, which (as the pre-
existing comment mentioned) we can assume to be nonzero
because there is always at least one magic byte at the
start of a segment, and this correctly finds the first
open slot.

Fixes #11