### PR TITLE
Enable stable rust compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - stable
 
 script:
   - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/zowens/commitlog"
 version = "0.1.1"
 edition = "2018"
 
+[features]
+# Enable benchmark of the private api. This flag should be used only
+# for benchmarking purposes!
+bench-private = []
+
 [dependencies]
 byteorder = "1.0"
 bytes = "0.5.0"
@@ -25,6 +30,7 @@ rand = "0.7"
 [[bench]]
 name = "index"
 harness = false
+required-features = ["bench-private"]
 
 [[bench]]
 name = "log-append"
@@ -37,3 +43,4 @@ harness = false
 [[bench]]
 name = "segment"
 harness = false
+required-features = ["bench-private"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "commitlog"
 readme = "README.md"
 repository = "https://github.com/zowens/commitlog"
 version = "0.1.1"
+edition = "2018"
 
 [dependencies]
 byteorder = "1.0"
@@ -17,5 +18,22 @@ memmap = "0.7"
 page_size = "0.4.1"
 
 [dev-dependencies]
+criterion = "0.3"
 env_logger = "0.7"
 rand = "0.7"
+
+[[bench]]
+name = "index"
+harness = false
+
+[[bench]]
+name = "log-append"
+harness = false
+
+[[bench]]
+name = "message"
+harness = false
+
+[[bench]]
+name = "segment"
+harness = false

--- a/benches/index.rs
+++ b/benches/index.rs
@@ -1,0 +1,49 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use commitlog::index::{Index, IndexBuf};
+use testutil::TestDir;
+
+mod testutil {
+    include!("../src/testutil.rs");
+}
+
+fn bench_find_exact(c: &mut Criterion) {
+    let dir = TestDir::new();
+    let mut index = Index::new(&dir, 10u64, 9000usize).unwrap();
+
+    for i in 0..10 {
+        let mut buf = IndexBuf::new(20, 10u64);
+        for j in 0..200 {
+            let off = 10u32 + (i * j);
+            buf.push(off as u64, off);
+        }
+        index.append(buf).unwrap();
+    }
+
+    index.flush_sync().unwrap();
+    c.bench_function("find extract", |b| {
+        b.iter(|| {
+            index.find(black_box(943)).unwrap();
+        })
+    });
+}
+
+fn bench_insert_flush(c: &mut Criterion) {
+    let dir = TestDir::new();
+    let mut index = Index::new(&dir, 10u64, 9000usize).unwrap();
+
+    c.bench_function("insert flush", |b| {
+        b.iter(|| {
+            let mut buf = IndexBuf::new(20, 10u64);
+            for j in 0..20 {
+                let off = 10u32 + j;
+                buf.push(off as u64, off);
+            }
+            index.append(buf).unwrap();
+            index.flush_sync().unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_find_exact, bench_insert_flush);
+criterion_main!(benches);

--- a/benches/log-append.rs
+++ b/benches/log-append.rs
@@ -1,57 +1,65 @@
-#![feature(test)]
+use criterion::{criterion_group, criterion_main, Criterion};
 
-extern crate commitlog;
-extern crate rand;
-extern crate test;
+use commitlog::message::MessageBuf;
+use commitlog::{CommitLog, LogOptions};
+use testutil::TestDir;
 
 mod testutil {
     include!("../src/testutil.rs");
 }
 
-use commitlog::message::*;
-use commitlog::*;
-use testutil::TestDir;
-
-#[bench]
-fn commitlog_append_10000(b: &mut test::Bencher) {
+fn commitlog_append_10000(c: &mut Criterion) {
     let dir = TestDir::new();
     let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();
-    b.iter(|| {
-        for _ in 0..10_000 {
-            log.append_msg(
-                "719c3b4556066a1c7a06c9d55959d003d9b46273aabe2 \
+
+    c.bench_function("append 10000", |b| {
+        b.iter(|| {
+            for _ in 0..10_000 {
+                log.append_msg(
+                    "719c3b4556066a1c7a06c9d55959d003d9b46273aabe2 \
                  eae15ef4ba78321ae2a68b0997a4abbd035a4cdbc8b27d701089a5af63a8b \
                  81f9dc16a874d0eda0983b79c1a6f79fe3ae61612ba2558562a85595f2f3f \
                  07fab8faba1b849685b61aad6b131b7041ca79cc662b4c5aad4d1b78fb103 \
                  4fafa2fe4f30207395e399c6d724",
-            )
-            .unwrap();
-        }
-        log.flush().unwrap();
+                )
+                .unwrap();
+            }
+            log.flush().unwrap();
+        })
     });
 }
 
-#[bench]
-fn commitlog_append_10000_batched(b: &mut test::Bencher) {
+fn commitlog_append_10000_batched(c: &mut Criterion) {
     let dir = TestDir::new();
     let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();
-    b.iter(|| {
-        let mut buf = MessageBuf::default();
-        for _ in 0..200 {
-            for _ in 0..50 {
-                buf.push(
-                    "719c3b4556066a1c7a06c9d55959d003d9b46273aabe2 \
+
+    c.bench_function("append 10000 batched", |b| {
+        b.iter(|| {
+            let mut buf = MessageBuf::default();
+            for _ in 0..200 {
+                for _ in 0..50 {
+                    buf.push(
+                        "719c3b4556066a1c7a06c9d55959d003d9b46273aabe2 \
                      eae15ef4ba78321ae2a68b0997a4abbd035a4cdbc8b27d701089a5af63a8b \
                      81f9dc16a874d0eda0983b79c1a6f79fe3ae61612ba2558562a85595f2f3f \
                      07fab8faba1b849685b61aad6b131b7041ca79cc662b4c5aad4d1b78fb103 \
                      4fafa2fe4f30207395e399c6d724",
-                );
+                    )
+                    .unwrap();
+                }
+                log.append(&mut buf).unwrap();
+                unsafe {
+                    buf.unsafe_clear();
+                }
             }
-            log.append(&mut buf).unwrap();
-            unsafe {
-                buf.unsafe_clear();
-            }
-        }
-        log.flush().unwrap();
+            log.flush().unwrap();
+        })
     });
 }
+
+criterion_group!(
+    benches,
+    commitlog_append_10000,
+    commitlog_append_10000_batched
+);
+criterion_main!(benches);

--- a/benches/message.rs
+++ b/benches/message.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use commitlog::message::{set_offsets, MessageBuf};
+
+fn bench_message_construct(c: &mut Criterion) {
+    c.bench_function("message construct", |b| {
+        b.iter(|| {
+            let mut msg_buf = MessageBuf::default();
+            msg_buf
+                .push(
+                    "719c3b4556066a1c7a06c9d55959d003d9b4627
+3aabe2eae15ef4ba78321ae2a68b0997a4abbd035a4cdbc8b27d701089a5af63a
+8b81f9dc16a874d0eda0983b79c1a6f79fe3ae61612ba2558562a85595f2f3f07
+fab8faba1b849685b61aad6b131b7041ca79cc662b4c5aad4d1b78fb1034fafa2
+fe4f30207395e399c6d724",
+                )
+                .unwrap();
+            msg_buf
+                .push(
+                    "2cea26f165640d448a9b89f1f871e6fca80a125
+5b1daea6752bf99d8c5f90e706deaecddf304b2bf5a5e72e32b29bc7c54018265
+d17317a670ea406fd7e6b485a19f5fb1efe686badb6599d45106b95b55695cd4e
+24729edb312a5dec1bc80e8d8b3ee4b69af1f3a9c801e7fb527e65f7c13c62bb3
+7261c0",
+                )
+                .unwrap();
+            set_offsets(&mut msg_buf, 1250);
+        })
+    });
+}
+
+criterion_group!(benches, bench_message_construct);
+criterion_main!(benches);

--- a/benches/segment.rs
+++ b/benches/segment.rs
@@ -1,0 +1,43 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use commitlog::message::MessageBuf;
+use commitlog::segment::Segment;
+use testutil::TestDir;
+
+mod testutil {
+    include!("../src/testutil.rs");
+}
+
+fn bench_segment_append(c: &mut Criterion) {
+    let path = TestDir::new();
+
+    let mut seg = Segment::new(path, 100u64, 1000 * 1024 * 1024).unwrap();
+    let payload = b"01234567891011121314151617181920";
+
+    c.bench_function("segment append", |b| {
+        b.iter(|| {
+            let mut buf = MessageBuf::default();
+            buf.push(payload).unwrap();
+            seg.append(&mut buf).unwrap();
+        })
+    });
+}
+
+fn bench_segment_append_flush(c: &mut Criterion) {
+    let path = TestDir::new();
+
+    let mut seg = Segment::new(path, 100u64, 1000 * 1024 * 1024).unwrap();
+    let payload = b"01234567891011121314151617181920";
+
+    c.bench_function("segment append flush", |b| {
+        b.iter(|| {
+            let mut buf = MessageBuf::default();
+            buf.push(payload).unwrap();
+            seg.append(&mut buf).unwrap();
+            seg.flush_sync().unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_segment_append, bench_segment_append_flush);
+criterion_main!(benches);

--- a/src/index.rs
+++ b/src/index.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::{u64, usize};
 
-/// Number of byes in each entry pair
+/// Number of bytes in each entry pair
 pub const INDEX_ENTRY_BYTES: usize = 8;
 /// Number of bytes contained in the base name of the file.
 pub const INDEX_FILE_NAME_LEN: usize = 20;

--- a/src/index.rs
+++ b/src/index.rs
@@ -552,7 +552,6 @@ mod tests {
     use env_logger;
     use std::fs;
     use std::path::PathBuf;
-    use test::test::Bencher;
 
     #[test]
     pub fn index() {
@@ -720,7 +719,7 @@ mod tests {
             let meta = fs::metadata(&index_path).unwrap();
             assert!(meta.is_file());
 
-            let mut index = Index::open(&index_path).unwrap();
+            let index = Index::open(&index_path).unwrap();
             assert_eq!(index.next_write_pos, 8);
             assert_eq!(AccessMode::Read, index.mode);
 
@@ -1052,41 +1051,5 @@ mod tests {
         assert_eq!(None, file_len);
         assert_eq!(15, index.next_offset());
         assert_eq!(5 * INDEX_ENTRY_BYTES, index.next_write_pos);
-    }
-
-    #[bench]
-    fn bench_find_exact(b: &mut Bencher) {
-        let dir = TestDir::new();
-        let mut index = Index::new(&dir, 10u64, 9000usize).unwrap();
-
-        for i in 0..10 {
-            let mut buf = IndexBuf::new(20, 10u64);
-            for j in 0..200 {
-                let off = 10u32 + (i * j);
-                buf.push(off as u64, off);
-            }
-            index.append(buf).unwrap();
-        }
-
-        index.flush_sync().unwrap();
-        b.iter(|| {
-            index.find(943).unwrap();
-        })
-    }
-
-    #[bench]
-    fn bench_insert_flush(b: &mut Bencher) {
-        let dir = TestDir::new();
-        let mut index = Index::new(&dir, 10u64, 9000usize).unwrap();
-
-        b.iter(|| {
-            let mut buf = IndexBuf::new(20, 10u64);
-            for j in 0..20 {
-                let off = 10u32 + j;
-                buf.push(off as u64, off);
-            }
-            index.append(buf).unwrap();
-            index.flush_sync().unwrap();
-        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,16 @@ extern crate env_logger;
 extern crate rand;
 
 mod file_set;
+#[cfg(feature = "bench-private")]
 pub mod index;
+#[cfg(not(feature = "bench-private"))]
+mod index;
 pub mod message;
 pub mod reader;
+#[cfg(feature = "bench-private")]
 pub mod segment;
+#[cfg(not(feature = "bench-private"))]
+mod segment;
 #[cfg(test)]
 mod testutil;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 //!     //    1 - second message
 //! }
 //! ```
-#![feature(test)]
 
 extern crate byteorder;
 extern crate crc32c;
@@ -55,14 +54,12 @@ extern crate env_logger;
 
 #[cfg(test)]
 extern crate rand;
-#[cfg(test)]
-extern crate test;
 
 mod file_set;
-mod index;
+pub mod index;
 pub mod message;
 pub mod reader;
-mod segment;
+pub mod segment;
 #[cfg(test)]
 mod testutil;
 
@@ -584,9 +581,9 @@ mod tests {
         let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();
         let mut buf = {
             let mut buf = MessageBuf::default();
-            buf.push(b"123456");
-            buf.push(b"789012");
-            buf.push(b"345678");
+            buf.push(b"123456").unwrap();
+            buf.push(b"789012").unwrap();
+            buf.push(b"345678").unwrap();
             buf
         };
         let range = log.append(&mut buf).unwrap();
@@ -741,14 +738,14 @@ mod tests {
     pub fn reopen_log_with_one_segment_write() {
         env_logger::try_init().unwrap_or(());
         let dir = TestDir::new();
-        let mut opts = LogOptions::new(&dir);
+        let opts = LogOptions::new(&dir);
         {
             let mut log = CommitLog::new(opts.clone()).unwrap();
-            log.append_msg("Test");
+            log.append_msg("Test").unwrap();
             log.flush().unwrap();
         }
         {
-            let mut log = CommitLog::new(opts.clone()).unwrap();
+            let log = CommitLog::new(opts.clone()).unwrap();
             assert_eq!(1, log.next_offset());
         }
     }
@@ -779,11 +776,11 @@ mod tests {
         // append 5 messages
         {
             let mut buf = MessageBuf::default();
-            buf.push(b"123456");
-            buf.push(b"789012");
-            buf.push(b"345678");
-            buf.push(b"aaaaaa");
-            buf.push(b"bbbbbb");
+            buf.push(b"123456").unwrap();
+            buf.push(b"789012").unwrap();
+            buf.push(b"345678").unwrap();
+            buf.push(b"aaaaaa").unwrap();
+            buf.push(b"bbbbbb").unwrap();
             log.append(&mut buf).unwrap();
         }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -37,7 +37,7 @@ impl LogSliceReader for MessageBufReader {
         use std::os::unix::fs::FileExt;
 
         let mut vec = vec![0; bytes];
-        try!(file.read_at(&mut vec, u64::from(file_position)));
+        file.read_at(&mut vec, u64::from(file_position))?;
         MessageBuf::from_bytes(vec)
     }
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -202,7 +202,6 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::PathBuf;
-    use test::Bencher;
 
     #[test]
     pub fn log_append() {
@@ -211,15 +210,15 @@ mod tests {
 
         {
             let mut buf = MessageBuf::default();
-            buf.push("12345");
+            buf.push("12345").unwrap();
             let meta = f.append(&mut buf).unwrap();
             assert_eq!(2, meta.starting_position);
         }
 
         {
             let mut buf = MessageBuf::default();
-            buf.push("66666");
-            buf.push("77777");
+            buf.push("66666").unwrap();
+            buf.push("77777").unwrap();
             let meta = f.append(&mut buf).unwrap();
             assert_eq!(27, meta.starting_position);
 
@@ -241,8 +240,8 @@ mod tests {
         {
             let mut f = Segment::new(&log_dir, 0, 1024).unwrap();
             let mut buf = MessageBuf::default();
-            buf.push("12345");
-            buf.push("66666");
+            buf.push("12345").unwrap();
+            buf.push("66666").unwrap();
             f.append(&mut buf).unwrap();
             f.flush_sync().unwrap();
         }
@@ -269,9 +268,9 @@ mod tests {
 
         {
             let mut buf = MessageBuf::default();
-            buf.push("0123456789");
-            buf.push("aaaaaaaaaa");
-            buf.push("abc");
+            buf.push("0123456789").unwrap();
+            buf.push("aaaaaaaaaa").unwrap();
+            buf.push("abc").unwrap();
             set_offsets(&mut buf, 0);
             f.append(&mut buf).unwrap();
         }
@@ -291,9 +290,9 @@ mod tests {
         let mut f = Segment::new(&log_dir, 0, 1024).unwrap();
 
         let mut buf = MessageBuf::default();
-        buf.push("0123456789");
-        buf.push("aaaaaaaaaa");
-        buf.push("abc");
+        buf.push("0123456789").unwrap();
+        buf.push("aaaaaaaaaa").unwrap();
+        buf.push("abc").unwrap();
         set_offsets(&mut buf, 0);
         let meta = f.append(&mut buf).unwrap();
 
@@ -320,9 +319,9 @@ mod tests {
 
         {
             let mut buf = MessageBuf::default();
-            buf.push("0123456789");
-            buf.push("aaaaaaaaaa");
-            buf.push("abc");
+            buf.push("0123456789").unwrap();
+            buf.push("aaaaaaaaaa").unwrap();
+            buf.push("abc").unwrap();
             set_offsets(&mut buf, 0);
             f.append(&mut buf).unwrap();
         }
@@ -333,7 +332,7 @@ mod tests {
 
         {
             let mut buf = MessageBuf::default();
-            buf.push("foo");
+            buf.push("foo").unwrap();
             set_offsets(&mut buf, 3);
             f.append(&mut buf).unwrap();
         }
@@ -378,9 +377,9 @@ mod tests {
         let mut f = Segment::new(&log_dir, 0, 1024).unwrap();
 
         let mut buf = MessageBuf::default();
-        buf.push("0123456789");
-        buf.push("aaaaaaaaaa");
-        buf.push("abc");
+        buf.push("0123456789").unwrap();
+        buf.push("aaaaaaaaaa").unwrap();
+        buf.push("abc").unwrap();
         set_offsets(&mut buf, 0);
         let meta = f.append(&mut buf).unwrap();
 
@@ -408,7 +407,7 @@ mod tests {
 
         let meta2 = {
             let mut buf = MessageBuf::default();
-            buf.push("zzzzzzzzzz");
+            buf.push("zzzzzzzzzz").unwrap();
             set_offsets(&mut buf, 1);
             f.append(&mut buf).unwrap()
         };
@@ -423,34 +422,5 @@ mod tests {
             .read_slice(&mut reader, 2, f.size() as u32 - 2)
             .expect("Read after second append failed");
         assert_eq!(2, msg_buf.len());
-    }
-
-    #[bench]
-    fn bench_segment_append(b: &mut Bencher) {
-        let path = TestDir::new();
-
-        let mut seg = Segment::new(path, 100u64, 100 * 1024 * 1024).unwrap();
-        let payload = b"01234567891011121314151617181920";
-
-        b.iter(|| {
-            let mut buf = MessageBuf::default();
-            buf.push(payload);
-            seg.append(&mut buf).unwrap();
-        });
-    }
-
-    #[bench]
-    fn bench_segment_append_flush(b: &mut Bencher) {
-        let path = TestDir::new();
-
-        let mut seg = Segment::new(path, 100u64, 100 * 1024 * 1024).unwrap();
-        let payload = b"01234567891011121314151617181920";
-
-        b.iter(|| {
-            let mut buf = MessageBuf::default();
-            buf.push(payload);
-            seg.append(&mut buf).unwrap();
-            seg.flush_sync().unwrap();
-        });
     }
 }


### PR DESCRIPTION
It was not possible to use stable rust toolchain because #[bench] is still not stable. So instead of unstable bench feature the project is now using criterion crate.
Also as a part of this commit all warning messages were fixed.