### PR TITLE
Add truncate_at which drops offset inclusively, fixes #29.

### DIFF
--- a/src/file_set.rs
+++ b/src/file_set.rs
@@ -143,7 +143,7 @@ impl FileSet {
         //    offset = 6
         //    [0 5 10 15] => split key 5
         //
-        // midpoint  is then used as the active index/segment pair
+        // midpoint is then used as the active index/segment pair
         let split_key = match self.closed.range(..=offset).next_back().map(|p| p.0).cloned() {
             Some(key) => {
                 trace!("File set split key for truncation {}", key);


### PR DESCRIPTION
I opened this PR and then realized I don't understand the relationship between the files and the offsets. This test fails consistently;
```
$ cargo test truncate_after_offset_removes_segments 
    Finished test [unoptimized + debuginfo] target(s) in 0.17s
     Running target/debug/deps/commitlog-f74130b8cc5772ff

running 1 test
test tests::truncate_after_offset_removes_segments ... FAILED

failures:

---- tests::truncate_after_offset_removes_segments stdout ----
thread 'tests::truncate_after_offset_removes_segments' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `4`: Invalid file count, expected {"00000000000000000002.log", "00000000000000000000.log", "00000000000000000002.index", "00000000000000000000.index"} got {"00000000000000000004.index", "00000000000000000002.index", "00000000000000000000.index", "00000000000000000002.log", "00000000000000000000.log", "00000000000000000004.log"}', src/lib.rs:960:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::truncate_after_offset_removes_segments

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 45 filtered out
```
