### PR TITLE
Add/improve some tests, especially around size limits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,19 +759,12 @@ mod tests {
     pub fn append_message_greater_than_max() {
         let dir = TestDir::new();
         let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();
-        //create vector with 1.2mb of size, u8 = 1 byte thus,
-        //1mb = 1000000 bytes, 1200000 items needed
-        let mut value = String::new();
-        let mut target = 0;
-        while target != 2000000 {
-            value.push('a');
-            target += 1;
-        }
+        // Try to write a value larger than the 1mb default message_max_bytes limit
+        let value = std::iter::repeat('a').take(1_200_000).collect::<String>();
         let res = log.append_msg(value);
-        //will fail if no error is found which means a message greater than the limit
-        // passed through
-        assert!(res.is_err());
+        assert!(matches!(res.err(), Some(AppendError::MessageSizeExceeded)));
         log.flush().unwrap();
+        assert_eq!(0, log.next_offset());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,7 +682,7 @@ mod tests {
         let dir = TestDir::new();
         let mut log = CommitLog::new(LogOptions::new(&dir)).unwrap();
         let value = std::iter::repeat('a').take(900_000).collect::<String>();
-        log.append_msg(value).unwrap();
+        log.append_msg(&value).unwrap();
         let res = log.read(0, ReadLimit::default());
         match res {
             Err(ReadError::Io(err)) => {
@@ -694,6 +694,15 @@ mod tests {
             }
             _ => panic!("Expected ReadError::Io"),
         }
+        assert_eq!(
+            value.as_bytes(),
+            log.read(0, ReadLimit::max_bytes(1_000_000))
+                .unwrap()
+                .iter()
+                .nth(0)
+                .unwrap()
+                .payload()
+        );
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -632,6 +632,8 @@ mod tests {
     pub fn messagebuf_fromiterator() {
         let buf = vec!["test", "123"].iter().collect::<MessageBuf>();
         assert_eq!(2, buf.len());
+        assert_eq!(b"test", buf.iter().nth(0).unwrap().payload());
+        assert_eq!(b"123", buf.iter().nth(1).unwrap().payload());
     }
 
     #[test]


### PR DESCRIPTION
Add/improve some tests, especially around message size limits.

After reading the documentation, and the tests, I wasn't clear about what happens when one tries to read a message larger than ReadLimit, so I added a test for it:

* so future users can see this at a glance by reading the tests, and
* to emphasize that this behavior, down to the exact `"Message exceeded max byte size"` error message text, is part of the client API: Matching this error message text is the only way for clients to know that they need to retry their read with a larger ReadLimit.  I find that I need to match this error text to detect this condition in a thing I'm writing that uses commitlog, and I'd feel better if the specific error text was guarded by a test.
* to possibly start a discussion about whether clients ought to be depending on error message text like this / if there should be a better way to signal this 'you need to retry with a larger ReadLimit' condition, (or maybe even a way for a client to know how big the ReadLimit needs to be to read the next message without continually retrying with slightly higher limits).  :)